### PR TITLE
Don't run action on release build tag uploads

### DIFF
--- a/.github/workflows/cfg-check.yml
+++ b/.github/workflows/cfg-check.yml
@@ -1,7 +1,10 @@
 name: Check pxt.json
 
 on:
-  push
+  push:
+    branches:
+      - 'master'
+      - 'main'
 
 jobs:
   check-cfg:


### PR DESCRIPTION
Fix the issue in https://forum.makecode.com/t/error-on-github-actions-for-makecode-arcade/6616/3 where creating a release gets an extra run of the build that will fail unnecessarily, sorry about that~